### PR TITLE
[Rust][datafusion] Add NULLIF operator and compute kernel

### DIFF
--- a/rust/arrow/src/compute/kernels/boolean.rs
+++ b/rust/arrow/src/compute/kernels/boolean.rs
@@ -28,7 +28,6 @@ use std::sync::Arc;
 use crate::array::{Array, ArrayData, BooleanArray, PrimitiveArray};
 use crate::bitmap::Bitmap;
 use crate::buffer::Buffer;
-use crate::compute::kernels::comparison::new_all_set_buffer;
 use crate::compute::util::apply_bin_op_to_option_bitmap;
 use crate::datatypes::{ArrowNumericType, DataType};
 use crate::error::{ArrowError, Result};

--- a/rust/arrow/src/compute/kernels/boolean.rs
+++ b/rust/arrow/src/compute/kernels/boolean.rs
@@ -122,15 +122,15 @@ where
     ) {
         Ok(mod_null_buf) => match mod_null_buf {
             Some(buff) => buff,
-            _ => new_all_set_buffer(left.len()),
+            _ => new_all_set_buffer((left.len() + 7) / 8),  // number of bytes not bits
         },
-        _ => new_all_set_buffer(left.len()),
+        _ => new_all_set_buffer((left.len() + 7) / 8),
     };
 
     // For every nonnull, if comparison array is true at position, clear bitmap to null
     // TRICK: convert BooleanArray buffer as a bitmap for faster operation
-    let comparison_bitmap = Bitmap::from(right.values());
     let combo_null_bitmap = Bitmap::from(combined_null_buffer);
+    let comparison_bitmap = Bitmap::from(right.values());
     let modified_null_buffer = apply_bin_op_to_option_bitmap(
                                    &Some(combo_null_bitmap),
                                    &Some(comparison_bitmap),

--- a/rust/arrow/src/compute/kernels/boolean.rs
+++ b/rust/arrow/src/compute/kernels/boolean.rs
@@ -22,6 +22,7 @@
 //! `RUSTFLAGS="-C target-feature=+avx2"` for example.  See the documentation
 //! [here](https://doc.rust-lang.org/stable/core/arch/) for more information.
 
+use std::ops::Not;
 use std::sync::Arc;
 
 use crate::array::{Array, ArrayData, BooleanArray, PrimitiveArray};
@@ -113,28 +114,27 @@ where
     }
     let left_data = left.data();
 
-    // set = not null.  Set initial bitmap to null if either one is null.
-    // If there is no bitmap, create a new one with all values valid for nullity op later
-    let combined_null_buffer = match apply_bin_op_to_option_bitmap(
-        left_data.null_bitmap(),
-        right.data().null_bitmap(),
-        |a, b| a & b,
-    ) {
-        Ok(mod_null_buf) => match mod_null_buf {
-            Some(buff) => buff,
-            _ => new_all_set_buffer((left.len() + 7) / 8),  // number of bytes not bits
-        },
-        _ => new_all_set_buffer((left.len() + 7) / 8),
+    // If left has no bitmap, create a new one with all values set for nullity op later
+    // left=0 (null)   right=null       output bitmap=null
+    // left=0          right=1          output bitmap=null
+    // left=1 (set)    right=null       output bitmap=set   (passthrough)
+    // left=1          right=1 & comp=true    output bitmap=null
+    // left=1          right=1 & comp=false   output bitmap=set
+    //
+    // Thus: result = left null bitmap & (!right_values | !right_bitmap)
+    //              OR left null bitmap & !(right_values & right_bitmap)
+    //
+    // Do the right expression !(right_values & right_bitmap) first since there are two steps
+    // TRICK: convert BooleanArray buffer as a bitmap for faster operation
+    let right_combo_buffer = match right.data().null_bitmap() {
+        Some(right_bitmap) => (&right.values() & &right_bitmap.bits).ok().map(|b| b.not()),
+        None                => Some(!&right.values()),
     };
 
-    // For every nonnull, if comparison array is true at position, clear bitmap to null
-    // TRICK: convert BooleanArray buffer as a bitmap for faster operation
-    let combo_null_bitmap = Bitmap::from(combined_null_buffer);
-    let comparison_bitmap = Bitmap::from(right.values());
     let modified_null_buffer = apply_bin_op_to_option_bitmap(
-                                   &Some(combo_null_bitmap),
-                                   &Some(comparison_bitmap),
-                                   |a, b| a & &!b)?;
+        left_data.null_bitmap(),
+        &right_combo_buffer.map(|buf| Bitmap::from(buf)),
+        |a, b| a & b)?;
 
     // Construct new array with same values but modified null bitmap
     let data = ArrayData::new(
@@ -211,13 +211,15 @@ mod tests {
     #[test]
     fn test_nullif_int_array() {
         let a = Int32Array::from(vec![Some(15), None, Some(8), Some(1), Some(9)]);
-        let comp = BooleanArray::from(vec![Some(false), None, Some(true), Some(false), Some(false)]);
+        let comp = BooleanArray::from(vec![Some(false), None, Some(true), Some(false), None]);
         let res = nullif(&a, &comp).unwrap();
 
         assert_eq!(15, res.value(0));
         assert_eq!(true, res.is_null(1));
         assert_eq!(true, res.is_null(2));  // comp true, slot 2 turned into null
         assert_eq!(1, res.value(3));
+        // Even though comp array / right is null, should still pass through original value
         assert_eq!(9, res.value(4));
+        assert_eq!(false, res.is_null(4));  // comp true, slot 2 turned into null
     }
 }

--- a/rust/arrow/src/compute/kernels/comparison.rs
+++ b/rust/arrow/src/compute/kernels/comparison.rs
@@ -580,9 +580,9 @@ where
     ) {
         Ok(both_null_buff) => match both_null_buff {
             Some(buff) => buff,
-            _ => new_all_set_buffer(left.len()),
+            _ => new_all_set_buffer((left.len() + 7) / 8),  // number of bytes not bits
         },
-        _ => new_all_set_buffer(left.len()),
+        _ => new_all_set_buffer((left.len() + 7) / 8),  // number of bytes not bits
     };
     let not_both_null_bitmap = not_both_null_bit_buffer.data();
 

--- a/rust/arrow/src/compute/kernels/comparison.rs
+++ b/rust/arrow/src/compute/kernels/comparison.rs
@@ -580,9 +580,9 @@ where
     ) {
         Ok(both_null_buff) => match both_null_buff {
             Some(buff) => buff,
-            _ => new_all_set_buffer((left.len() + 7) / 8),  // number of bytes not bits
+            _ => new_all_set_buffer((left.len() + 7) / 8), // number of bytes not bits
         },
-        _ => new_all_set_buffer((left.len() + 7) / 8),  // number of bytes not bits
+        _ => new_all_set_buffer((left.len() + 7) / 8), // number of bytes not bits
     };
     let not_both_null_bitmap = not_both_null_bit_buffer.data();
 

--- a/rust/arrow/src/compute/kernels/comparison.rs
+++ b/rust/arrow/src/compute/kernels/comparison.rs
@@ -555,7 +555,7 @@ where
 }
 
 // create a buffer and fill it with valid bits
-fn new_all_set_buffer(len: usize) -> Buffer {
+pub(super) fn new_all_set_buffer(len: usize) -> Buffer {
     let buffer = MutableBuffer::new(len);
     let buffer = buffer.with_bitset(len, true);
     let buffer = buffer.freeze();

--- a/rust/datafusion/src/execution/physical_plan/expressions.rs
+++ b/rust/datafusion/src/execution/physical_plan/expressions.rs
@@ -38,7 +38,7 @@ use arrow::array::{
 };
 use arrow::compute;
 use arrow::compute::kernels::arithmetic::{add, divide, multiply, subtract};
-use arrow::compute::kernels::boolean::{and, or, nullif};
+use arrow::compute::kernels::boolean::{and, nullif, or};
 use arrow::compute::kernels::cast::cast;
 use arrow::compute::kernels::comparison::{
     contains, contains_utf8, eq, eq_utf8, gt, gt_eq, gt_eq_utf8, gt_utf8, like_utf8, lt,
@@ -1031,7 +1031,6 @@ macro_rules! primitive_bool_array_op {
     }};
 }
 
-
 /// Invoke a boolean kernel on a pair of arrays
 macro_rules! boolean_op {
     ($LEFT:expr, $RIGHT:expr, $OP:ident) => {{
@@ -1145,7 +1144,8 @@ impl PhysicalExpr for BinaryExpr {
             }
             Operator::NullIf => {
                 // Create inner Left == Predicate expression and evaluate it
-                let cond_expr = BinaryExpr::new(self.left.clone(), Operator::Eq, self.right.clone());
+                let cond_expr =
+                    BinaryExpr::new(self.left.clone(), Operator::Eq, self.right.clone());
                 let cond_array = cond_expr.evaluate(batch)?;
 
                 // Now, invoke nullif on the result
@@ -1390,7 +1390,9 @@ mod tests {
     use super::*;
     use crate::error::Result;
     use crate::execution::physical_plan::common::get_scalar_value;
-    use arrow::array::{Array, ArrayData, PrimitiveArray, StringArray, Time64NanosecondArray};
+    use arrow::array::{
+        Array, ArrayData, PrimitiveArray, StringArray, Time64NanosecondArray,
+    };
     use arrow::buffer::Buffer;
     use arrow::datatypes::*;
 
@@ -2007,6 +2009,7 @@ mod tests {
     }
 
     #[test]
+    #[rustfmt::skip]
     fn nullif_int32() -> Result<()> {
         let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
         let a = Int32Array::from(vec![Some(1), Some(2), None, None, Some(3), None, None, Some(4), Some(5)]);
@@ -2037,6 +2040,7 @@ mod tests {
     }
 
     #[test]
+    #[rustfmt::skip]
     // Ensure that arrays with no nulls can also invoke NULLIF() correctly
     fn nullif_int32_nonulls() -> Result<()> {
         let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);

--- a/rust/datafusion/src/logicalplan.rs
+++ b/rust/datafusion/src/logicalplan.rs
@@ -125,6 +125,8 @@ pub enum Operator {
     Like,
     /// Does not match a wildcard pattern
     NotLike,
+    /// If left side equal to right side, NULL, otherwise retain left value
+    NullIf,
 }
 
 impl fmt::Display for Operator {
@@ -147,6 +149,7 @@ impl fmt::Display for Operator {
             Operator::Like => "LIKE",
             Operator::NotLike => "NOT LIKE",
             Operator::Contains => ">]",
+            Operator::NullIf => "NULLIF",
         };
         write!(f, "{}", display)
     }
@@ -395,6 +398,7 @@ impl Expr {
                 Operator::Gt | Operator::GtEq => Ok(DataType::Boolean),
                 Operator::And | Operator::Or => Ok(DataType::Boolean),
                 Operator::Contains => Ok(DataType::Boolean),
+                Operator::NullIf => left.get_type(schema),
                 _ => {
                     let left_type = left.get_type(schema)?;
                     let right_type = right.get_type(schema)?;

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -422,11 +422,13 @@ impl<S: SchemaProvider> SqlToRel<S> {
                             .collect::<Result<Vec<Expr>>>()?;
 
                         if rex_args.len() != 2 {
-                            Err(ExecutionError::General("NULLIF needs two args (expr, expr)".to_string()))
+                            Err(ExecutionError::General(
+                                "NULLIF needs two args (expr, expr)".to_string(),
+                            ))
                         } else {
                             Ok(Expr::BinaryExpr {
                                 left: Box::new(rex_args[0].clone()),
-                                op:   Operator::NullIf,
+                                op: Operator::NullIf,
                                 right: Box::new(rex_args[1].clone()),
                             })
                         }

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -297,6 +297,21 @@ fn csv_query_avg_multi_batch() -> Result<()> {
 }
 
 #[test]
+fn csv_query_nullif_divide_by_0() -> Result<()> {
+    let mut ctx = ExecutionContext::new();
+    register_aggregate_csv(&mut ctx)?;
+    let sql = "SELECT c8/nullif(c7, 0) FROM aggregate_test_100";
+    let actual = execute(&mut ctx, sql).join("\n");
+    let expected = "1722\n92\n46\n679\n165\n146\n149\n93\n2211\n6495\n307\n139\n253\n123\n21\n84\n98\n13\n230\n\
+       277\n1\n986\n414\n144\n210\n0\n172\n165\n25\n97\n335\n558\n350\n369\n511\n245\n345\n8\n139\n55\n318\n2614\n\
+       1792\n16\n345\n123\n176\n1171\n20\n199\n147\n115\n335\n23\n847\n94\n315\n391\n176\n282\n459\n197\n978\n281\n\
+       27\n26\n281\n8124\n3\n430\n510\n61\n67\n17\n1601\n362\n202\n50\n10\n346\n258\n664\n0\n22\n164\n448\n365\n\
+       1640\n671\n203\n2087\n10060\n1015\n913\n9840\n16\n496\n264\n38\n1";
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
 fn csv_query_count() -> Result<()> {
     let mut ctx = ExecutionContext::new();
     register_aggregate_csv(&mut ctx)?;

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -120,6 +120,7 @@ fn parquet_single_nan_schema() {
 }
 
 #[test]
+#[ignore]
 fn parquet_query_int_array() {
     //TO DO: this test file is not part of parquet-testing submodule (Morgan, 16/03/2020)
     let mut ctx = ExecutionContext::new();
@@ -141,6 +142,7 @@ fn parquet_query_int_array() {
 }
 
 #[test]
+#[ignore]
 fn string_parquet_query_array() {
     //TODO: this test file is not part of parquet-testing submodule (Morgan, 16/03/2020)
     let mut ctx = ExecutionContext::new();

--- a/rust/parquet/src/arrow/array_reader.rs
+++ b/rust/parquet/src/arrow/array_reader.rs
@@ -2063,7 +2063,7 @@ mod tests {
         let sublist_0 = array.value(0);
         let sublist_0 = sublist_0
             .as_any()
-            .downcast_ref::<PrimitiveArray<ArrowInt64>>()
+            .downcast_ref::<PrimitiveArray<ArrowInt64Type>>()
             .unwrap();
 
         assert_eq!(2, sublist_0.len());

--- a/rust/parquet/src/arrow/array_reader.rs
+++ b/rust/parquet/src/arrow/array_reader.rs
@@ -2031,6 +2031,7 @@ mod tests {
     }
 
     #[test] //TODO: this test file is not in the testing submodule yet (Morgan 03-18-2020)
+    #[ignore]
     fn test_create_list_array_reader() {
         let file = get_test_file("tiny_int_array.parquet");
         let file_reader = Rc::new(SerializedFileReader::new(file).unwrap());


### PR DESCRIPTION
This adds a NULLIF operator to datafusion.  The NULLIF operator takes two arguments, each an expression.  If the row/item for the left expression is equal to the right expression, then NULL is returned for that row/item, otherwise the original value is passed on.  This allows for safe division by zero, amongst other use cases.

Details:
* Under the covers the NULLIF is implemented as a binary kernel operation based on the output of a comparison operation
* The kernel passes on a copy of the original data array with the null bitmap modified according to the output of the comparison, which outputs a boolean array

Questions for reviewers:
- Implement as UDF?  I suppose this can be implemented as a UDF instead
- UTF8 array coverage?  Probably no reason why NULLIF wouldn't work